### PR TITLE
Publish Trichotomy of Control post and correct date

### DIFF
--- a/_posts/2026-06-20-trichotomy-of-control.markdown
+++ b/_posts/2026-06-20-trichotomy-of-control.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Trichotomy of Control"
-date: 2024-12-26 00:00
+date: 2026-06-20 00:00
 comments: true
 categories: ["philosophy"]
 description: "A Stoic reflection on using the trichotomy of control to face difficult software projects, separate outcomes from actions, and focus energy where it can actually make a difference."
@@ -38,5 +38,4 @@ The success of a difficult undertaking is in those things that is partially with
 
 If your brain asks you whether or not this challenge is going to be a success then give it The Farmer and His Horse answer. [Maybe, we'll see](https://www.youtube.com/watch?v=QmYG0LIznkk).
 
-Hopefully you found this entry useful. If you'd like more Stoicism consider sharing this.
 


### PR DESCRIPTION
### Motivation
- Publish the existing Trichotomy of Control draft as a dated blog post so it appears in the site feed with the correct publication date.
- Ensure the post front matter date matches the desired publish date and remove the closing thank-you/share sentence to match editorial intent.

### Description
- Moved the draft from `_drafts/2024-06-12-trichotomy-of-control.markdown` to `_posts/2026-06-20-trichotomy-of-control.markdown` so it is treated as a published post.
- Updated the front matter `date` field to `2026-06-20 00:00` to match the post filename and intended publish date.
- Removed the closing sentence `Hopefully you found this entry useful. If you'd like more Stoicism consider sharing this.` so the post ends after the final link.
- No other content changes were made.

### Testing
- Running `bundle exec jekyll build` initially failed due to the local `mise.toml` not being trusted in the environment.
- After trusting the local config with `mise trust` and installing gems with `bundle install`, `bundle exec jekyll build` completed successfully with no build errors.
- The site generation step confirmed the post renders without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a367cc2bf7483309ecd2ab358d96682)